### PR TITLE
Added optional support for pulsar-pulse-functions bi-directional alias resolution.

### DIFF
--- a/pulsar.el
+++ b/pulsar.el
@@ -498,7 +498,7 @@ If FUNC is a function alias, return the function alias chain."
   (let ((aliases))
     (mapatoms (lambda (sym)
                 (when (and
-                       (fboundp sym)
+                       (commandp sym)
                        (memq (symbol-function sym) fns))
                   (push sym aliases))))
     aliases))


### PR DESCRIPTION
Re: #11, I added a new user option called ```pulsar-resolve-pulse-function-aliases``` and which is set to nil, by default. The new feature should have no ill effects on users that do not enable it.

Function alias resolution takes place upon enabling ```pulsar-mode```. I do not think the implementation has sufficiently high runtime cost to require that users invoke the resolution function separately but this may vary and we may need to revisit this choice. Let me know what you think and how this performs for you.

To maintain backward compatibility for people who use ```setq``` vs. ```custom-set``` or ```:custom``` via ```use-package``` or the ```customize``` UI for ```pulsar-pulse-functions```, I did not add a ```:set``` handler to ```pulsar-pulse-functions```'s ```defcustom```. This is an option we could choose to relocate resolution into set-time only but at the cost of compatibility with people who use ```setq``` (a seemingly universally bad habit of which I am guilty). The manual is silent on a preferred method of setting. Obviously, even if we automated via ```defcustom``` and without a heavy-handed variable watcher, using ```add-to-list```, et.al., will also result in skipping alias resolution and would need documentation and exposing the alias function more publicly.

For backward compatibility with Emacs prior to Emacs 29, I duplicated the core function added in Emacs 29.1 called ```function-alias-p``` in a private method. If you prefer to require 29.1+, I can remove the copy and use the core function.