### PR TITLE
pulsar--on enable pulsar-mode only if necessary.

### DIFF
--- a/pulsar.el
+++ b/pulsar.el
@@ -482,7 +482,8 @@ This is a buffer-local mode.  Also check `pulsar-global-mode'."
   "Enable `pulsar-mode'."
   (unless (minibufferp)
     (let (inhibit-quit)
-      (pulsar-mode 1))))
+      (unless pulsar-mode
+        (pulsar-mode 1)))))
 
 ;;;###autoload
 (define-globalized-minor-mode pulsar-global-mode pulsar-mode pulsar--on)


### PR DESCRIPTION
Now that we call ```pulsar--resolve-function-aliases``` in pulsar-mode, this creates performance issues when called constantly as it does in a global minor mode.
