### PR TITLE
Fix evil pulsing operations

### DIFF
--- a/pulsar.el
+++ b/pulsar.el
@@ -77,14 +77,8 @@ pulse.  Only applies when `pulsar-pulse' is non-nil."
     dired-goto-file
     dired-next-dirline
     dired-prev-dirline
-    evil-delete
-    evil-delete-char
-    evil-delete-line
-    evil-delete-marks
     evil-goto-first-line
     evil-goto-line
-    evil-paste-after
-    evil-paste-before
     evil-scroll-down
     evil-scroll-line-to-bottom
     evil-scroll-line-to-center
@@ -92,7 +86,6 @@ pulse.  Only applies when `pulsar-pulse' is non-nil."
     evil-scroll-page-down
     evil-scroll-page-up
     evil-scroll-up
-    evil-undo
     evil-window-bottom
     evil-window-delete
     evil-window-down
@@ -166,6 +159,10 @@ This only takes effect when `pulsar-mode' (buffer-local) or
   '(append-next-kill
     delete-region
     evil-delete
+    evil-delete-line
+    evil-paste-after
+    evil-paste-before
+    evil-undo
     evil-yank
     evil-yank-line
     kill-line


### PR DESCRIPTION
- Editing commands should pulse the region, not the entire line.
- evil-delete-char shouldn't pulse anything, it's the equivalent to the DEL key.
- evil-delete-marks isn't an editing command (it removes invisible marks from the buffer).